### PR TITLE
replaced input text with html5 textarea field (multiline support)

### DIFF
--- a/commands.php
+++ b/commands.php
@@ -131,7 +131,7 @@ print_header("Nagios Command Editor");
 			<?php echo $lilac->element_desc("command_name", "nagios_commands_desc"); ?><br />
 			<br />
 			<b>Command Line:</b><br />
-			<input type="text" size="100" name="command_manage[command_line]" value="<?php echo isset($command) ? htmlentities($command->getLine()) : '';?>">
+			<textarea cols="100" rows=4 name="command_manage[command_line]"><?php echo isset($command) ? htmlentities($command->getLine()) : '';?></textarea>
 			<?php echo $lilac->element_desc("command_line", "nagios_commands_desc"); ?><br />
 			<br />
 			<b>Command Description:</b><br />


### PR DESCRIPTION
Hey guys, I was bored to never see entirely the nagios command_line into the too small input text, so I replaced the html tag <input type="text"> by the HTML5 <textarea> counterpart, allowing multiline field.

It's far much nicer and IMHO should be merged without delay ;) Also we might/should generalize the use of HTML tags when possible...

Cheers, and merry Xmas