### PR TITLE
Add stop job button

### DIFF
--- a/export.php
+++ b/export.php
@@ -73,6 +73,16 @@ if(isset($_GET['id'])) {
 			//$success = "Restarted Export Job";
 		}
 	}
+	if(isset($_GET['action']) && $_GET['action'] == "stop") {
+		if($exportJob->getStatusCode() < ExportJob::STATUS_FINISHED) {
+			$exportJob->setStatusCode(ExportJob::STATUS_FAILED);
+			$exportJob->setStatus("Stopped");
+			$exportJob->addWarning("Stopped Export Job");
+			$exportJob->save();
+			exec("pkill -f 'php exporter/export.php' > /dev/null");
+			$success = "Stopped Export Job";
+		}
+	}
 	if(isset($_GET['delete'])) {
 		// We want to delete the job!
 		exec("pkill -f 'php exporter/export.php ".$exportJob->getId()."' > /dev/null");
@@ -292,6 +302,13 @@ if(!isset($exportJob))	{
 				<td><?php echo $job->getStatus();?></td>
 				<td><a class="btn btn-info" href="export.php?id=<?php echo $job->getId();?>">View Job</td>
 				<td><a class="btn btn-primary" href="export.php?id=<?php echo $job->getId();?>&action=restart">Restart</a></td>
+				<?php
+				if($job->getStatusCode() < ExportJob::STATUS_FINISHED) {
+				?>
+					<td><a class="btn btn-warning" href="export.php?id=<?php echo $job->getId();?>&action=stop">Stop</a></td>
+				<?php
+				}
+				?>
 			</tr>
 			<?php
 		}
@@ -425,12 +442,15 @@ else {
 	<div id="completemsg" class="roundedcorner_success_box" <?php if($exportJob->getStatusCode() != ExportJob::STATUS_FINISHED ) { ?>style="display: none; margin-left:0px;"<?php } else { ?>style="margin-left:0px;"<?php } ?>>
 	   <div class="roundedcorner_success_top"><div></div></div>
 	      <div class="roundedcorner_success_content">
-	      Export Job Complete.  Content Exported Successfully.
+	      Export Job Complete. Content Exported Successfully.
 	      </div>
 	   <div class="roundedcorner_success_bottom"><div></div></div>
 	</div>
 
-	<a class="btn btn-primary" href="export.php?id=<?php echo $exportJob->getId();?>&action=restart">Restart Job</a> <a class="btn btn-danger" href="export.php?id=<?php echo $exportJob->getId();?>&delete=1" onclick="javascript:return confirmDelete();">Remove Job</a> <a class="btn btn-default" href="export.php">Return To Exporter</a>
+	<a class="btn btn-primary" href="export.php?id=<?php echo $exportJob->getId();?>&action=restart">Restart Job</a>
+	<a class="btn btn-warning" href="export.php?id=<?php echo $exportJob->getId();?>&action=stop">Stop Job</a>
+	<a class="btn btn-danger" href="export.php?id=<?php echo $exportJob->getId();?>&delete=1" onclick="javascript:return confirmDelete();">Remove Job</a>
+	<a class="btn btn-default" href="export.php">Return To Exporter</a>
 	<?php
 	print_window_footer();
 	print_window_header("Job Log");

--- a/includes/output.php
+++ b/includes/output.php
@@ -310,7 +310,7 @@ function print_header($title = null) {
 	}
 		
 	function confirmDelete() {
-		return confirm("Are you sure ?");
+		return confirm("Are you sure?");
   	}
 
 	function checkLine(lineid,checkid) {


### PR DESCRIPTION
Users complains when they want to stop a job, they click on "Remove" as there are no "stop" button.
This PR fixes it.

1. Adding a "stop" on the exporter page. It's available only when a job is running
![exporter1](https://user-images.githubusercontent.com/232433/54618086-b5de3580-4a62-11e9-8b23-dc63b2e90c01.png)

![exporter2](https://user-images.githubusercontent.com/232433/54618145-d1e1d700-4a62-11e9-98e3-03b5330861cb.png)

2. Adding a "stop" button in the detailed exporter page. It kills the process and creates a log entry.

![exporter3](https://user-images.githubusercontent.com/232433/54618192-e6be6a80-4a62-11e9-84e7-e218fcd45848.png)


